### PR TITLE
Add feature to enable user delete a record.

### DIFF
--- a/index.js
+++ b/index.js
@@ -256,6 +256,22 @@ app.patch('/api/v1/red-flags/:id/comment', (req, res) => {
   });
 });
 
+//  Delete a record
+app.delete('/api/v1/red-flags/:id', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  if ([...redFlagRecords.keys()].includes(id) && redFlagRecords.get(id) !== null) {
+    redFlagRecords.set(id, null);
+    return res.status(200).send({
+      status: id,
+      message: 'No content: Red-flag record has been deleted',
+    });
+  }
+  return res.status(404).send({
+    status: 404,
+    error: 'Not found: Red-flag record not found',
+  });
+});
+
 // Set up port
 const PORT = process.env.PORT || 2000;
 


### PR DESCRIPTION
Add API feature to enable users delete a red-flag record from the iReporter application. This feature uses the Delete method.